### PR TITLE
bug fix limited multiattack

### DIFF
--- a/LimitedMultiattack/Server_AdvanceTurn.lua
+++ b/LimitedMultiattack/Server_AdvanceTurn.lua
@@ -140,15 +140,14 @@ function Server_AdvanceTurn_Order(game, order, result, skipThisOrder, addNewOrde
 		end
 	end
 	if(order.proxyType == 'GameOrderAttackTransfer') then
+		-- it says in the mod configuration that when MaxAttacks set to 0 there is unlimited multi attacks, but I believe you get an alert of you set it to 0
 		if(UbrigeAngriffe[order.From] > 0 or (activated[order.PlayerID] and Mod.Settings.MaxAttacks == 0))then
 			if(result.IsSuccessful)then
-				-- removed the else statement, it was the main issue of the bug
+				-- check if the attack was a transfer, if this is the case do nothing
+				-- Warzone itself makes sure these armies are not able to move again
 				if(game.ServerGame.LatestTurnStanding.Territories[order.From].OwnerPlayerID ~= game.ServerGame.LatestTurnStanding.Territories[order.To].OwnerPlayerID)then
-					UbrigeAngriffe[order.To] = UbrigeAngriffe[order.From];
-				end
-				-- changed if statement below, otherwise it would treat a transfer the same as an attack
-				if(UbrigeAngriffe[order.To] ~= 0 and game.ServerGame.LatestTurnStanding.Territories[order.From].OwnerPlayerID ~= game.ServerGame.LatestTurnStanding.Territories[order.To].OwnerPlayerID)then
-					UbrigeAngriffe[order.To] = UbrigeAngriffe[order.To] - 1;
+					-- order was an attack, so we can set the table value at order.To to the table value at order.From - 1
+					UbrigeAngriffe[order.To] = UbrigeAngriffe[order.From] - 1;
 				end
 			else
 				if(order.PlayerID == game.ServerGame.LatestTurnStanding.Territories[order.From].OwnerPlayerID)then

--- a/LimitedMultiattack/Server_AdvanceTurn.lua
+++ b/LimitedMultiattack/Server_AdvanceTurn.lua
@@ -142,9 +142,11 @@ function Server_AdvanceTurn_Order(game, order, result, skipThisOrder, addNewOrde
 	if(order.proxyType == 'GameOrderAttackTransfer') then
 		if(UbrigeAngriffe[order.From] > 0 or (activated[order.PlayerID] and Mod.Settings.MaxAttacks == 0))then
 			if(result.IsSuccessful)then
+				-- removed the else statement, it was the main issue of the bug
 				if(game.ServerGame.LatestTurnStanding.Territories[order.From].OwnerPlayerID ~= game.ServerGame.LatestTurnStanding.Territories[order.To].OwnerPlayerID)then
 					UbrigeAngriffe[order.To] = UbrigeAngriffe[order.From];
 				end
+				-- changed if statement below, otherwise it would treat a transfer the same as an attack
 				if(UbrigeAngriffe[order.To] ~= 0 and game.ServerGame.LatestTurnStanding.Territories[order.From].OwnerPlayerID ~= game.ServerGame.LatestTurnStanding.Territories[order.To].OwnerPlayerID)then
 					UbrigeAngriffe[order.To] = UbrigeAngriffe[order.To] - 1;
 				end

--- a/LimitedMultiattack/Server_AdvanceTurn.lua
+++ b/LimitedMultiattack/Server_AdvanceTurn.lua
@@ -144,15 +144,9 @@ function Server_AdvanceTurn_Order(game, order, result, skipThisOrder, addNewOrde
 			if(result.IsSuccessful)then
 				if(game.ServerGame.LatestTurnStanding.Territories[order.From].OwnerPlayerID ~= game.ServerGame.LatestTurnStanding.Territories[order.To].OwnerPlayerID)then
 					UbrigeAngriffe[order.To] = UbrigeAngriffe[order.From];
-				else
-					UbrigeAngriffe[order.To] = -1;
 				end
-				if(Mod.Settings.MaxAttacks == 0 and UbrigeAngriffe[order.To] ~= 0)then
+				if(UbrigeAngriffe[order.To] ~= 0 and game.ServerGame.LatestTurnStanding.Territories[order.From].OwnerPlayerID ~= game.ServerGame.LatestTurnStanding.Territories[order.To].OwnerPlayerID)then
 					UbrigeAngriffe[order.To] = UbrigeAngriffe[order.To] - 1;
-				else
-					if(UbrigeAngriffe[order.To] ~= 0)then
-						UbrigeAngriffe[order.To] = UbrigeAngriffe[order.To] - 1;
-					end
 				end
 			else
 				if(order.PlayerID == game.ServerGame.LatestTurnStanding.Territories[order.From].OwnerPlayerID)then


### PR DESCRIPTION
removed some lines and / or merged them
also setting maximum multiattacks to 0 will show an alert telling you you're not able to set it to 0, while it does tell you 0=infinitive and the code is there to make it work

https://www.warzone.com/MultiPlayer?GameID=29167526
test game with Krinid, pls note that the bug (transferring A -> B caused all orders after from B to be cancelled) is solved (watch territory balearic sea/island)