### PR TITLE
cleaner suggestion for Server_AdvanceTurn_Order

### DIFF
--- a/LimitedMultiattack/Server_AdvanceTurn.lua
+++ b/LimitedMultiattack/Server_AdvanceTurn.lua
@@ -140,6 +140,9 @@ function Server_AdvanceTurn_Order(game, order, result, skipThisOrder, addNewOrde
 		end
 	end
 	if(order.proxyType == 'GameOrderAttackTransfer') then
+		-- Without the line below every attack that takes place without controlling the attacking territory will result in a skip,
+		-- Watching turns back without this line results in slow 'order got skipped' list, while just returning and letting Warzone make 0 attack from it will make it a lot faster and cleaner orderlist
+		if(order.PlayerID ~= game.ServerGame.LatestTurnStanding.Territories[order.From].OwnerPlayerID) then return end;
 		-- it says in the mod configuration that when MaxAttacks set to 0 there is unlimited multi attacks, but I believe you get an alert of you set it to 0
 		if(UbrigeAngriffe[order.From] > 0 or (activated[order.PlayerID] and Mod.Settings.MaxAttacks == 0))then
 			if(result.IsSuccessful)then


### PR DESCRIPTION
Right now the mod adds a "Mod skipped attack/transfer order" for every attack that fails due to not controlling the attacking territory. If we let the mod do nothing (by returning nothing) this will get avoided and Warzone itself makes from all of those attacks a 0 army attack, resulting in a clean and quick oversight when watching the turn
![afbeelding](https://user-images.githubusercontent.com/51970740/148056054-607b14ef-cf97-4cc2-8a20-057e6251fe6c.png)
(note that "Attackfailed" is from another mod)
all those skips come from orders I made but couldn't execute due to not controlling the attacking territory